### PR TITLE
Fix query parameter containing pipe is not encoded

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
                     return namePart + "=" + data[partialComponent]["data"][data[partialComponent]["data"].length-1];
                 else {
                     var minLength = Math.min(data[partialComponent]["data"].length, data[name]["data"].length);
-                    return namePart + "=" + data[partialComponent]["data"][minLength-1] + "|" + encodeURIComponent(partialComponent);
+                    return namePart + "=" + encodeURIComponent(data[partialComponent]["data"][minLength-1] + "|" + partialComponent);
                 }
             } else
                 return namePart + "=full";


### PR DESCRIPTION
The current query parameter handling encodes the parameter name but does not fully encode the value. Specifically, the pipe character used in the query is not a valid url character but is not encoded as it should.